### PR TITLE
Api migrate

### DIFF
--- a/BlizzardApiReader.Core.Tests/ApiReaderTests.cs
+++ b/BlizzardApiReader.Core.Tests/ApiReaderTests.cs
@@ -1,0 +1,61 @@
+﻿using BlizzardApiReader.Core.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Threading.Tasks;
+
+namespace BlizzardApiReader.Core.Tests
+{
+    [TestClass]
+    public class ApiReaderTests
+    {
+        [TestMethod]
+        public void GetAsync_ShouldThrowIfInvalidTest()
+        {
+            var reader = new ApiReader();
+            // reader has no configuration nor token
+
+            Task.Run(async () =>
+            {
+                try
+                {
+                    await reader.GetAsync<object>("anyquery");
+                    Assert.Fail();
+                }
+                catch
+                {
+
+                }
+
+            }).GetAwaiter().GetResult();
+
+        }
+
+        [TestMethod]
+        public void GetAsync_ShouldThrowWithoutTokenTest()
+        {
+            var reader = new ApiReader(ApiConfiguration.CreateDefault());
+            Task.Run(async () =>
+            {
+                try
+                {
+                    await reader.GetAsync<object>("anyquery");
+                    Assert.Fail();
+                }
+                catch (NullReferenceException ex)
+                {
+                
+                }
+                catch
+                {
+                    Assert.Fail();
+                }
+
+            }).GetAwaiter().GetResult();
+
+        }
+
+
+        //TODO: continue adding tests with mock lib
+
+    }
+}

--- a/BlizzardApiReader.Core.Tests/Models/ApiConfigurationTests.cs
+++ b/BlizzardApiReader.Core.Tests/Models/ApiConfigurationTests.cs
@@ -5,6 +5,11 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 /*
 namespace BlizzardApiReader.Core.Tests
 {
+
+
+    ** need to update these tests to the new system
+    * 
+
     [TestClass]
     public class ApiConfigurationTests
     {

--- a/BlizzardApiReader.Core.Tests/Models/ApiConfigurationTests.cs
+++ b/BlizzardApiReader.Core.Tests/Models/ApiConfigurationTests.cs
@@ -1,123 +1,109 @@
 ﻿using BlizzardApiReader.Core.Enums;
+using BlizzardApiReader.Core.Extensions;
 using BlizzardApiReader.Core.Models;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-/*
+
 namespace BlizzardApiReader.Core.Tests
 {
-
-
-    ** need to update these tests to the new system
-    * 
-
     [TestClass]
     public class ApiConfigurationTests
     {
+        private readonly Locale defaultLocale;
+        private readonly Region defaultRegion;
+
         #region Constructor
         [TestMethod]
         public void Constructor_NoParameter_DefaultConfigurations()
         {
             var configuration = new ApiConfiguration();
 
-            configuration.ApiRegion.Should().BeEquivalentTo(Region.UnitedStates);
-            configuration.ResultLocale.Should().BeEquivalentTo(Locale.AmericanEnglish);
-            configuration.ApiKey.Should().BeNull();
+            configuration.ApiRegion.Should().BeEquivalentTo(defaultRegion);
+            configuration.ResultLocale.Should().BeEquivalentTo(defaultLocale);
+            configuration.ClientId.Should().BeNull();
+            configuration.ClientSecret.Should().BeNull();
         }
 
-        [TestMethod]
-        public void Constructor_ApiKeyParameter_DefaultConfigurations()
-        {
-            var configuration = new ApiConfiguration("anyapikey");
-
-            configuration.ApiRegion.Should().BeEquivalentTo(Region.UnitedStates);
-            configuration.ResultLocale.Should().BeEquivalentTo(Locale.AmericanEnglish);
-        }
-
-        [TestMethod]
-        public void Constructor_RegionParameter_DefaultLocale()
-        {
-            var configuration = new ApiConfiguration(Region.Europe, "anyapikey");
-
-            configuration.ApiRegion.Should().BeEquivalentTo(Region.Europe);
-            configuration.ResultLocale.Should().BeEquivalentTo(Locale.BritishEnglish);
-        }
-
-        [TestMethod]
-        public void Constructor_AllParameters_Configurations()
-        {
-            var configuration = new ApiConfiguration(Region.Europe, Locale.Korean, "anyapikey");
-
-            configuration.ApiRegion.Should().BeEquivalentTo(Region.Europe);
-            configuration.ResultLocale.Should().BeEquivalentTo(Locale.Korean);
-        }
         #endregion
 
         #region CreateEmpty
         [TestMethod]
-        public void CreateEmpty_NoParameter_DefaultConfigurations()
+        public void CreateDefault_NoParameter_DefaultConfigurations()
         {
-            var config = ApiConfiguration.CreateEmpty();
+            var config = ApiConfiguration.CreateDefault();
 
-            config.ApiRegion.Should().BeEquivalentTo(Region.UnitedStates);
-            config.ResultLocale.Should().BeEquivalentTo(Locale.AmericanEnglish);
-            config.ApiKey.Should().BeNull();
+            config.ApiRegion.Should().BeEquivalentTo(defaultRegion);
+            config.ResultLocale.Should().BeEquivalentTo(defaultLocale);
+            config.ClientId.Should().BeNull();
+            config.ClientSecret.Should().BeNull();
         }
         #endregion
 
         #region SetRegion
+
         [TestMethod]
-        public void SetRegion_RegionParameter_ExpectedRegion()
+        public void SetRegion_ShouldSetCorrectlyTest()
         {
-            var config = new ApiConfiguration(Region.UnitedStates, Locale.AmericanEnglish, "anyapikey");
+            var config = new ApiConfiguration();
+
+            config.SetRegion(Region.Taiwan);
+            config.ApiRegion.Should().BeEquivalentTo(Region.Taiwan);
+        }
+
+        [TestMethod]
+        public void SetRegionWithDefaultLocaleTest()
+        {
+            var config = new ApiConfiguration();
+
+            config.SetRegion(Region.SoutheastAsia, true);
+            config.ApiRegion.Should().BeEquivalentTo(Region.SoutheastAsia);
+            config.ResultLocale.Should().BeEquivalentTo(Region.SoutheastAsia.GetDefaultLocale());
+        }
+
+
+        [TestMethod]
+        public void SetRegion_ShouldNotOverrideLocaleWhenFalse()
+        {
+            var config = new ApiConfiguration();
 
             config = config.SetRegion(Region.Korea);
             config.ApiRegion.Should().BeEquivalentTo(Region.Korea);
-            config.ResultLocale.Should().BeEquivalentTo(Locale.AmericanEnglish);
+            config.ResultLocale.Should().BeEquivalentTo(defaultLocale);
         }
 
-        [TestMethod]
-        public void SetRegion_UseDefaultLocale_ExpectedLocale()
-        {
-            var config = new ApiConfiguration(Region.UnitedStates, Locale.AmericanEnglish, "anyapikey");
-
-            config = config.SetRegion(Region.Korea, true);
-            config.ApiRegion.Should().BeEquivalentTo(Region.Korea);
-            config.ResultLocale.Should().BeEquivalentTo(Locale.Korean);
-        }
-
-        [TestMethod]
-        public void SetRegion_DoNotUseDefaultLocale_ExpectedLocale()
-        {
-            var config = new ApiConfiguration(Region.UnitedStates, Locale.AmericanEnglish, "anyapikey");
-
-            config = config.SetRegion(Region.Korea, false);
-            config.ApiRegion.Should().BeEquivalentTo(Region.Korea);
-            config.ResultLocale.Should().BeEquivalentTo(Locale.AmericanEnglish);
-        }
         #endregion
 
         #region SetLocale
         [TestMethod]
-        public void SetLocale_LocaleParameter_ExpectedLocale()
+        public void SetLocale_ShouldSetCorrectlyTest()
         {
-            var config = new ApiConfiguration(Region.UnitedStates, Locale.AmericanEnglish, "anyapikey");
+            var config = new ApiConfiguration();
 
             config = config.SetLocale(Locale.TraditionalChinese);
-            config.ApiRegion.Should().BeEquivalentTo(Region.UnitedStates);
+            config.ApiRegion.Should().BeEquivalentTo(defaultRegion);
             config.ResultLocale.Should().BeEquivalentTo(Locale.TraditionalChinese);
         }
         #endregion
 
-        #region UseDefaultLocale
         [TestMethod]
-        public void UseDefaultLocale_NoParameter_ExpectedLocale()
+        public void SetClientId_ShouldSetCorrectlyTest()
         {
-            var config = new ApiConfiguration(Region.UnitedStates, Locale.Korean, "anyapikey");
+            var config = new ApiConfiguration();
 
-            config = config.UseDefaultLocale();
-            config.ResultLocale.Should().BeEquivalentTo(Locale.AmericanEnglish);
+            config.SetClientId("test");
+            config.ClientId.Should().Be("test");
+            config.ClientSecret.Should().BeNull();
         }
-        #endregion
+
+        [TestMethod]
+        public void SetClientSecret_ShouldSetCorrectlyTest()
+        {
+            var config = new ApiConfiguration();
+            config.SetClientSecret("test");
+            config.ClientSecret.Should().Be("test");
+            config.ClientId.Should().BeNull();
+        }
+
+
     }
 }
-*/

--- a/BlizzardApiReader.Core.Tests/Models/ApiConfigurationTests.cs
+++ b/BlizzardApiReader.Core.Tests/Models/ApiConfigurationTests.cs
@@ -2,7 +2,7 @@
 using BlizzardApiReader.Core.Models;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-
+/*
 namespace BlizzardApiReader.Core.Tests
 {
     [TestClass]
@@ -115,3 +115,4 @@ namespace BlizzardApiReader.Core.Tests
         #endregion
     }
 }
+*/

--- a/BlizzardApiReader.Core.Tests/Models/ApiWebClientTests.cs
+++ b/BlizzardApiReader.Core.Tests/Models/ApiWebClientTests.cs
@@ -1,10 +1,11 @@
 ﻿using BlizzardApiReader.Core.Enums;
 using BlizzardApiReader.Core.Models;
+using BlizzardApiReader.Diablo.Models;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
 using System.Net.Http;
 using System.Threading.Tasks;
+
 
 namespace BlizzardApiReader.Core.Tests
 {
@@ -12,24 +13,8 @@ namespace BlizzardApiReader.Core.Tests
     public class ApiWebClientTests
     {
 
+        //TODO: Add tests
 
-        [TestMethod]
-        public void Test()
-        {
-            Task.Run(async () =>
-            {
-                ApiWebClient client = new ApiWebClient();
-                var config = ApiConfiguration.Default().SetRegion(Region.Europe).SetClientId("invalid")
-                .SetClientSecret("invalid");
-                
-
-                var request = await client.RequestAccessTokenAsync(config);
-
-                string token = await request.Content.ReadAsStringAsync();
-
-                throw new Exception(token);
-            }).GetAwaiter().GetResult();
-
-        }
+       
     }
 }

--- a/BlizzardApiReader.Core.Tests/Models/ApiWebClientTests.cs
+++ b/BlizzardApiReader.Core.Tests/Models/ApiWebClientTests.cs
@@ -1,0 +1,35 @@
+﻿using BlizzardApiReader.Core.Enums;
+using BlizzardApiReader.Core.Models;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace BlizzardApiReader.Core.Tests
+{
+    [TestClass]
+    public class ApiWebClientTests
+    {
+
+
+        [TestMethod]
+        public void Test()
+        {
+            Task.Run(async () =>
+            {
+                ApiWebClient client = new ApiWebClient();
+                var config = ApiConfiguration.Default().SetRegion(Region.Europe).SetClientId("invalid")
+                .SetClientSecret("invalid");
+                
+
+                var request = await client.RequestAccessTokenAsync(config);
+
+                string token = await request.Content.ReadAsStringAsync();
+
+                throw new Exception(token);
+            }).GetAwaiter().GetResult();
+
+        }
+    }
+}

--- a/BlizzardApiReader.Core.Tests/Models/ApiWebClientTests.cs
+++ b/BlizzardApiReader.Core.Tests/Models/ApiWebClientTests.cs
@@ -1,10 +1,4 @@
-﻿using BlizzardApiReader.Core.Enums;
-using BlizzardApiReader.Core.Models;
-using BlizzardApiReader.Diablo.Models;
-using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Net.Http;
-using System.Threading.Tasks;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 
 namespace BlizzardApiReader.Core.Tests

--- a/BlizzardApiReader.Core/ApiReader.cs
+++ b/BlizzardApiReader.Core/ApiReader.cs
@@ -6,12 +6,13 @@ using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using BlizzardApiReader.Core.Models;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace BlizzardApiReader.Core
 {
     public class ApiReader
     {
-        private static readonly string Url = "https://REGION.api.battle.net";
+        private const string url = "https://REGION.api.blizzard.com";
 
         /// <summary>
         /// Default configuration will be used if api reader does not have a local instance of ApiConfiguration
@@ -21,9 +22,13 @@ namespace BlizzardApiReader.Core
 
         public ApiConfiguration Configuration;
 
+        private IWebClient webClient;
+        private string token;
+
         public ApiReader(ApiConfiguration apiConfiguration = null)
         {
             Configuration = apiConfiguration;
+            webClient = new ApiWebClient();
         }
 
         public static void SetDefaultConfiguration(ApiConfiguration configuration)
@@ -38,7 +43,7 @@ namespace BlizzardApiReader.Core
                 throw new RateLimitReachedException("http request was blocked by RateLimiter");
 
             string urlRequest = parseUrl(query);
-            HttpResponseMessage response = await makeHttpRequest(urlRequest);
+            HttpResponseMessage response = await webClient.MakeHttpRequestAsync(urlRequest);
             limiters.NotifyAll(this, response);
 
             if (response.IsSuccessStatusCode)
@@ -47,7 +52,20 @@ namespace BlizzardApiReader.Core
                 return JsonConvert.DeserializeObject<T>(json);
             }
 
-            return default(T);
+            return default;
+        }
+
+        public async Task<string> RequestToken()
+        {
+            var response = await webClient.RequestAccessTokenAsync(getConfiguration());
+            if (response.IsSuccessStatusCode)
+            {
+                string json = await response.Content.ReadAsStringAsync();
+                JObject jObject = JObject.Parse(json);
+                return (string)jObject["access_token"];
+            }
+            //TODO: Add better error handling
+            throw new HttpRequestException("response code was not successful");
         }
 
         private void verifyConfigurationIsValid()
@@ -62,20 +80,11 @@ namespace BlizzardApiReader.Core
             query = parseSpecialCharacters(query);
 
             string region = getConfiguration().GetRegionString();
-            string newUrl = Url.Replace("REGION", region.ToLower());
-            newUrl += query + "?locale=" + getConfiguration().GetLocaleString() + "&apikey=" + getConfiguration().ApiKey;
+            string newUrl = url.Replace("REGION", region.ToLower());
+            newUrl += query + "?locale=" + getConfiguration().GetLocaleString() + "&token=" + token;
             return newUrl;
         }
 
-        private async Task<HttpResponseMessage> makeHttpRequest(string urlRequest)
-        {
-            using (HttpClient client = new HttpClient())
-            {
-                client.DefaultRequestHeaders.Accept.Clear();
-                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-                return await client.GetAsync(urlRequest);
-            }
-        }
 
 
         private string parseSpecialCharacters(string s)

--- a/BlizzardApiReader.Core/ApiReader.cs
+++ b/BlizzardApiReader.Core/ApiReader.cs
@@ -20,6 +20,7 @@ namespace BlizzardApiReader.Core
         private static ApiConfiguration defaultConfig { get; set; }
         private static LimitersList limiters { get; } = new LimitersList();
 
+
         public ApiConfiguration Configuration;
 
         private IWebClient webClient;
@@ -34,6 +35,11 @@ namespace BlizzardApiReader.Core
         public static void SetDefaultConfiguration(ApiConfiguration configuration)
         {
             defaultConfig = configuration;
+        }
+
+        public static void ClearDefaultConfiguration()
+        {
+            defaultConfig = null;
         }
 
         public async Task<T> GetAsync<T>(string query)

--- a/BlizzardApiReader.Core/ApiWebClient.cs
+++ b/BlizzardApiReader.Core/ApiWebClient.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using BlizzardApiReader.Core.Models;
+
+namespace BlizzardApiReader.Core
+{
+    public class ApiWebClient : IWebClient
+    {
+
+        private const string AUTH_URL = "https://REGION.battle.net/oauth/token";
+
+
+        public async Task<HttpResponseMessage> MakeHttpRequestAsync(string urlRequest)
+        {
+            using (HttpClient client = new HttpClient())
+            {
+                client.DefaultRequestHeaders.Accept.Clear();
+                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                return await client.GetAsync(urlRequest);
+            }
+        }
+
+        public async Task<HttpResponseMessage> RequestAccessTokenAsync(ApiConfiguration configuration)
+        {
+            using (HttpClient client = new HttpClient())
+            {
+                client.DefaultRequestHeaders.Accept.Clear();
+                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+                client.DefaultRequestHeaders.Authorization = authenticate(configuration.ClientId, configuration.ClientSecret);
+                var requestContent = new FormUrlEncodedContent(new Dictionary<string, string>
+                {
+                    { "grant_type", "client_credentials" }
+                });
+                string url = AUTH_URL.Replace("REGION", configuration.GetRegionString());
+
+                return await client.PostAsync(url, requestContent);
+            }
+        }
+
+        private AuthenticationHeaderValue authenticate(string user, string password)
+        {
+            String encoded = Convert.ToBase64String(Encoding.GetEncoding("ISO-8859-1").GetBytes(user + ":" + password));
+            return new AuthenticationHeaderValue("Basic", encoded);
+        }
+    }
+}

--- a/BlizzardApiReader.Core/Exceptions/BadResponseException.cs
+++ b/BlizzardApiReader.Core/Exceptions/BadResponseException.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+
+namespace BlizzardApiReader.Core.Exceptions
+{
+    public class BadResponseException : Exception
+    {
+        public HttpResponseMessage ResponseMessage;
+
+        public BadResponseException(string message, HttpResponseMessage responseMessage) : base(message)
+        {
+            ResponseMessage = responseMessage;
+        }
+
+        public BadResponseException(HttpResponseMessage responseMessage) : base()
+        {
+            ResponseMessage = responseMessage;
+        }
+    }
+}

--- a/BlizzardApiReader.Core/IWebClient.cs
+++ b/BlizzardApiReader.Core/IWebClient.cs
@@ -1,0 +1,14 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+using BlizzardApiReader.Core.Models;
+namespace BlizzardApiReader.Core
+{
+    public interface IWebClient
+    {
+
+        Task<HttpResponseMessage> MakeHttpRequestAsync(string query);
+
+        Task<HttpResponseMessage> RequestAccessTokenAsync(ApiConfiguration configuration);
+
+    }
+}

--- a/BlizzardApiReader.Core/Models/ApiConfiguration.cs
+++ b/BlizzardApiReader.Core/Models/ApiConfiguration.cs
@@ -8,74 +8,28 @@ namespace BlizzardApiReader.Core.Models
     {
         public Region ApiRegion;
         public Locale ResultLocale;
-        public string ApiKey;
+        public string ClientId;
+        public string ClientSecret;
 
-        /// <summary>
-        /// Initialize ApiConfiguration with default configurations and empty api key
-        /// Default configurations:
-        /// - Region.UnitedStates
-        /// - Locale.AmericanEnglish
-        /// </summary>
-        public ApiConfiguration() : this(null)
-        {
-
-        }
-
-        /// <summary>
-        /// Initialize ApiConfiguration with default configurations and api key
-        /// Default configurations:
-        /// - Region.UnitedStates
-        /// - Locale.AmericanEnglish
-        /// </summary>
-        /// <param name="apiKey">ApiKey to set</param>
-        public ApiConfiguration(string apiKey) : this(Region.UnitedStates, apiKey)
-        {
-
-        }
-
-        /// <summary>
-        /// Initialize ApiConfiguration with locale based on default locale of region and api key
-        /// </summary>
-        /// <param name="region">Region to set</param>
-        /// <param name="apiKey">ApiKey to set</param>
-        public ApiConfiguration(Region region, string apiKey) : this(region, region.GetDefaultLocale(), apiKey)
-        {
-
-        }
-
-        /// <summary>
-        /// Initialize ApiConfiguration
-        /// </summary>
-        /// <param name="region">Region to set. Defaults to UnitedStates</param>
-        /// <param name="locale">Locale to set. Defaults to AmericanEnglish</param>
-        /// <param name="apiKey">ApiKey to set</param>
-        public ApiConfiguration(Region region, Locale locale, string apiKey)
-        {
-            ApiRegion = region;
-            ResultLocale = locale;
-            ApiKey = apiKey;
-        }
-
-        /// <summary>
-        /// Default configurations: Region.UnitedStates, Locale.AmericanEnglish
-        /// </summary>
-        [Obsolete("Enum values and are non-nullable and will always default to the first value within the enumeration even if no value was explicitly assigned. Creating an empty configuration is impossible, default configurations will be used. Please use constructor method instead")]
-        public static ApiConfiguration CreateEmpty()
+       
+        public static ApiConfiguration Default()
         {
             return new ApiConfiguration();
         }
 
-        public ApiConfiguration SetApiKey(string key)
+        public ApiConfiguration SetClientId(string clientId)
         {
-            ApiKey = key;
+            ClientId = clientId;
             return this;
         }
 
-        /// <summary>
-        /// Set the region of the ApiConfiguration
-        /// </summary>
-        /// <param name="region">The region to set</param>
-        /// <returns>This instance of ApiConfiguration</returns>
+
+        public ApiConfiguration SetClientSecret(string clientSecret)
+        {
+            ClientSecret = clientSecret;
+            return this;
+        }
+
         public ApiConfiguration SetRegion(Region region)
         {
             return SetRegion(region, false);
@@ -102,18 +56,6 @@ namespace BlizzardApiReader.Core.Models
             ResultLocale = locale;
             return this;
         }
-
-        /// <summary>
-        /// Will use the default locale for the configuration region, must be called only after setting the Region
-        /// </summary>
-        /// <returns></returns>
-        [Obsolete("Please use overload of SetRegion to assign default locale of Region to configuration locale")]
-        public ApiConfiguration UseDefaultLocale()
-        {
-            ResultLocale = ApiRegion.GetDefaultLocale();
-            return this;
-        }
-
 
         /// <summary>
         /// Declare this Configuration as the global default configuration, it will be used when no configuration is provided to the api reader.

--- a/BlizzardApiReader.Core/Models/ApiConfiguration.cs
+++ b/BlizzardApiReader.Core/Models/ApiConfiguration.cs
@@ -12,7 +12,7 @@ namespace BlizzardApiReader.Core.Models
         public string ClientSecret;
 
        
-        public static ApiConfiguration Default()
+        public static ApiConfiguration CreateDefault()
         {
             return new ApiConfiguration();
         }


### PR DESCRIPTION
* Notable changes: 
URLs have changed to the new API
Extracted HttpRequests behind an interface to allow better unit testing
Added Client Auth
SendTokenRequest() needed to be called before GetAsync
GetAsync In ApiReader now throws exception when response code is not successful.

ApiConfiguration has changed to accept ClientSecret and ClientID instead of ApiKey
Therefore, the ApiConfigurationTests needs to be updated (Commented them for now) 

 I won't merge until we're sure this is ready and don't cause any problem.
So far, I've tested it on a couple diablo apis and it seems fine for the most part.