### PR TITLE
Suggested changes to API migration

### DIFF
--- a/BlizzardApiReader.Core/ApiReader.cs
+++ b/BlizzardApiReader.Core/ApiReader.cs
@@ -23,7 +23,8 @@ namespace BlizzardApiReader.Core
         public ApiConfiguration Configuration;
 
         private IWebClient webClient;
-        private string token;
+        private string _token;
+        private DateTime _tokenExpiration;
 
         public ApiReader(ApiConfiguration apiConfiguration = null)
         {
@@ -39,6 +40,11 @@ namespace BlizzardApiReader.Core
         public async Task<T> GetAsync<T>(string query)
         {
             throwIfInvalidRequest();
+
+            if (!IsValidToken())
+            {
+                await SendTokenRequest();
+            }
 
             string urlRequest = parseUrl(query);
             HttpResponseMessage response = await webClient.MakeHttpRequestAsync(urlRequest);
@@ -67,8 +73,10 @@ namespace BlizzardApiReader.Core
             {
                 string json = await response.Content.ReadAsStringAsync();
                 JObject jObject = JObject.Parse(json);
-                token = (string)jObject["access_token"];
-                return token;
+                _token = (string)jObject["access_token"];
+                int expiresInSeconds = (int)jObject["expires_in"];
+                _tokenExpiration = DateTime.Now.AddSeconds(expiresInSeconds);
+                return _token;
             }
             //TODO: Add better error handling
             throw new HttpRequestException("response code was not successful");
@@ -78,13 +86,20 @@ namespace BlizzardApiReader.Core
         private void throwIfInvalidRequest()
         {
 
-            if (String.IsNullOrEmpty(token))
-                throw new NullReferenceException("Token is null, Send a token request first");
-
             verifyConfigurationIsValid();
 
             if (limiters.AnyReachedLimit())
                 throw new RateLimitReachedException("http request was blocked by RateLimiter");
+        }
+        private bool IsValidToken()
+        {
+            if (String.IsNullOrEmpty(_token)
+                || DateTime.Now > _tokenExpiration)
+            {
+                return false;
+            }
+
+            return true;
         }
 
 
@@ -101,7 +116,7 @@ namespace BlizzardApiReader.Core
 
             string region = getConfiguration().GetRegionString();
             string newUrl = url.Replace("REGION", region.ToLower());
-            newUrl += query + "?locale=" + getConfiguration().GetLocaleString() + "&access_token=" + token;
+            newUrl += query + "?locale=" + getConfiguration().GetLocaleString() + "&access_token=" + _token;
             return newUrl;
         }
 

--- a/BlizzardApiReader.Core/Models/ApiConfiguration.cs
+++ b/BlizzardApiReader.Core/Models/ApiConfiguration.cs
@@ -11,6 +11,19 @@ namespace BlizzardApiReader.Core.Models
         public string ClientId;
         public string ClientSecret;
 
+        public ApiConfiguration() : this(Region.UnitedStates)
+        {
+
+        }
+        public ApiConfiguration(Region region) : this(region, region.GetDefaultLocale())
+        {
+
+        }
+        public ApiConfiguration(Region region, Locale locale)
+        {
+
+        }
+
        
         public static ApiConfiguration Default()
         {

--- a/BlizzardApiReader.Core/Models/ApiConfiguration.cs
+++ b/BlizzardApiReader.Core/Models/ApiConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using BlizzardApiReader.Core.Enums;
+using BlizzardApiReader.Core.Enums;
 using BlizzardApiReader.Core.Extensions;
 using System;
 
@@ -11,20 +11,11 @@ namespace BlizzardApiReader.Core.Models
         public string ClientId;
         public string ClientSecret;
 
-        public ApiConfiguration() : this(Region.UnitedStates)
-        {
-
-        }
-        public ApiConfiguration(Region region) : this(region, region.GetDefaultLocale())
-        {
-
-        }
-        public ApiConfiguration(Region region, Locale locale)
+        public ApiConfiguration()
         {
 
         }
 
-       
         public static ApiConfiguration Default()
         {
             return new ApiConfiguration();

--- a/BlizzardApiReader.Core/Models/ApiConfiguration.cs
+++ b/BlizzardApiReader.Core/Models/ApiConfiguration.cs
@@ -1,4 +1,4 @@
-using BlizzardApiReader.Core.Enums;
+﻿using BlizzardApiReader.Core.Enums;
 using BlizzardApiReader.Core.Extensions;
 using System;
 
@@ -13,9 +13,9 @@ namespace BlizzardApiReader.Core.Models
 
         public ApiConfiguration()
         {
-
+            ResultLocale = ApiRegion.GetDefaultLocale();
         }
-
+       
         public static ApiConfiguration Default()
         {
             return new ApiConfiguration();


### PR DESCRIPTION
Suggested changes for pull request #38 which migrates the API from the old Developer portal to the new Developer portal requiring OAuth.

When using the WorldOfWarcratAPI or DiabloApi I was unable to send a request token, instead implemented automatic retrieval of token if the token either...
1. Does not exist
2. Has expired