### PR TITLE
Changed how ApiWebClient works with HttpClient

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: csharp
+dist: trusty
 solution: BlizzardApiReader.sln
 mono: none
 dotnet: 2.1.500
 script:
- - dotnet restore
+ - dotnet test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: csharp
 dist: trusty
-solution: BlizzardApiReader.sln
 mono: none
 dotnet: 2.1.500
  

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ dotnet: 2.1.500
  
 jobs:
  include:
-  stage: Build
-  script:
-   - dotnet restore
-   - dotnet build
-  stage: Tests
-  script:
-   - dotnet test
+  - stage: Build
+    script:
+     - dotnet restore
+     - dotnet build
+  - stage: Tests
+    script:
+     - dotnet test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,13 @@ dist: trusty
 solution: BlizzardApiReader.sln
 mono: none
 dotnet: 2.1.500
-script:
- - dotnet test
+ 
+jobs:
+ include:
+  - stage: Build
+  script:
+   - dotnet restore
+   - dotnet build
+  - stage: Tests
+  script:
+   - dotnet test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: csharp
 dist: trusty
+solution: BlizzardApiReader.sln
 mono: none
 dotnet: 2.1.500
  

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ dotnet: 2.1.500
  
 jobs:
  include:
-  - stage: Build
+  stage: Build
   script:
    - dotnet restore
    - dotnet build
-  - stage: Tests
+  stage: Tests
   script:
    - dotnet test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: csharp
+solution: BlizzardApiReader.sln
+mono: none
+dotnet: 2.1.5
+script:
+ - dotnet restore

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: csharp
 solution: BlizzardApiReader.sln
 mono: none
-dotnet: 2.1.5
+dotnet: 2.1.500
 script:
  - dotnet restore

--- a/BlizzardApiReader.Core.Tests/ApiReaderTests.cs
+++ b/BlizzardApiReader.Core.Tests/ApiReaderTests.cs
@@ -16,13 +16,13 @@ namespace BlizzardApiReader.Core.Tests
         [TestMethod]
         public void GetAsync_ShouldThrowIfInvalidTest()
         {
-            var reader = new ApiReader();
-            // reader has no configuration nor token
-
             Task.Run(async () =>
             {
                 try
                 {
+                    var reader = new ApiReader();
+                    // reader has no configuration nor token
+
                     await reader.GetAsync<object>("anyquery");
                     Assert.Fail();
                 }
@@ -49,7 +49,7 @@ namespace BlizzardApiReader.Core.Tests
                 response.Setup(i => i.IsSuccessful()).Returns(true);
                 response.Setup(i => i.ReadContentAsync()).ReturnsAsync(json);
 
-                client.Setup(i => i.RequestAccessTokenAsync(defaultConfig)).ReturnsAsync(response.Object);
+                client.Setup(i => i.RequestAccessTokenAsync()).ReturnsAsync(response.Object);
 
                 var reader = new ApiReader(defaultConfig, client.Object);
                 try
@@ -75,7 +75,7 @@ namespace BlizzardApiReader.Core.Tests
                 var response = new Mock<IApiResponse>();
                 response.Setup(i => i.IsSuccessful()).Returns(false);
 
-                client.Setup(i => i.RequestAccessTokenAsync(defaultConfig)).ReturnsAsync(response.Object);
+                client.Setup(i => i.RequestAccessTokenAsync()).ReturnsAsync(response.Object);
                 var reader = new ApiReader(defaultConfig, client.Object);
                 try
                 {

--- a/BlizzardApiReader.Core.Tests/ApiReaderTests.cs
+++ b/BlizzardApiReader.Core.Tests/ApiReaderTests.cs
@@ -6,6 +6,7 @@ using FluentAssertions;
 using System.Net.Http;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using System.Reflection;
 
 namespace BlizzardApiReader.Core.Tests
 {
@@ -98,7 +99,7 @@ namespace BlizzardApiReader.Core.Tests
         }
 
         [TestMethod]
-        public void SendRequestToken_ShouldRequestNewIfExpired()
+        public void SendRequest_ShouldRequestANewTokenIfExpired()
         {
 
             Task.Run(async () =>
@@ -111,7 +112,7 @@ namespace BlizzardApiReader.Core.Tests
                 var client = new Mock<IWebClient>();
                 var response = new Mock<IApiResponse>();
                 response.Setup(i => i.IsSuccessful()).Returns(true);
-                response.Setup(i => i.ReadContentAsync()).ReturnsAsync(valid);
+                response.Setup(i => i.ReadContentAsync()).ReturnsAsync(expired);
 
                 client.Setup(i => i.RequestAccessTokenAsync()).ReturnsAsync(response.Object);
                 client.Setup(i => i.MakeApiRequestAsync(It.IsAny<string>())).ReturnsAsync(response.Object);
@@ -119,6 +120,8 @@ namespace BlizzardApiReader.Core.Tests
                 var reader = new ApiReader(defaultConfig, client.Object);
                 try
                 {
+                    await reader.GetAsync<Dictionary<string, string>>("anything");
+                    response.Setup(i => i.ReadContentAsync()).ReturnsAsync(valid);
                     var answer = await reader.GetAsync<Dictionary<string, string>>("anything");
                     answer.Should().BeEquivalentTo(expectedDict);
                 }

--- a/BlizzardApiReader.Core.Tests/Limiters/ApiResponseTests.cs
+++ b/BlizzardApiReader.Core.Tests/Limiters/ApiResponseTests.cs
@@ -29,7 +29,7 @@ namespace BlizzardApiReader.Core.Tests
         public void ReadContent_ShouldMatch()
         {
             string hello = "Hello";
-            var msg = new HttpResponseMessage(System.Net.HttpStatusCode.BadRequest);
+            var msg = new HttpResponseMessage(System.Net.HttpStatusCode.OK);
             msg.Content = new StringContent(hello);
             var response = new ApiResponse(msg);
             Task.Run(async () =>

--- a/BlizzardApiReader.Core.Tests/Limiters/ApiResponseTests.cs
+++ b/BlizzardApiReader.Core.Tests/Limiters/ApiResponseTests.cs
@@ -1,0 +1,41 @@
+﻿using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BlizzardApiReader.Core.Tests
+{
+    [TestClass]
+    public class ApiResponseTests
+    {
+        [TestMethod]
+        public void ApiResponse_ShouldBeSuccesful()
+        {
+            var response = new ApiResponse(new HttpResponseMessage(System.Net.HttpStatusCode.OK));
+            response.IsSuccessful().Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void ApiResponse_ShouldBeUnsuccesful()
+        {
+            var response = new ApiResponse(new HttpResponseMessage(System.Net.HttpStatusCode.BadRequest));
+            response.IsSuccessful().Should().BeFalse();
+        }
+        
+        [TestMethod]
+        public void ReadContent_ShouldMatch()
+        {
+            string hello = "Hello";
+            var msg = new HttpResponseMessage(System.Net.HttpStatusCode.BadRequest);
+            msg.Content = new StringContent(hello);
+            var response = new ApiResponse(msg);
+            Task.Run(async () =>
+            {
+                return await response.ReadContentAsync();
+            }).GetAwaiter().GetResult().Should().Be(hello);
+        }
+    }
+}

--- a/BlizzardApiReader.Core.Tests/Limiters/LimitersListTests.cs
+++ b/BlizzardApiReader.Core.Tests/Limiters/LimitersListTests.cs
@@ -1,0 +1,61 @@
+﻿using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BlizzardApiReader.Core.Tests
+{
+    [TestClass]
+    public class LimitersListTests
+    {
+        [TestMethod]
+        public void AddRemoveCases()
+        {
+            var limiter1 = new TimeRateLimiter(TimeSpan.FromSeconds(10), 5);
+            var limiter2 = new TimeRateLimiter(TimeSpan.FromMinutes(1), 5);
+            var limiters = new LimitersList();
+            limiters.Clear();
+            limiters.Add(limiter1);
+            Action failedRemove = () => limiters.Remove(limiter2);
+            failedRemove.Should().Throw<KeyNotFoundException>();
+            Action successfulRemove = () => limiters.Remove(limiter1);
+            successfulRemove.Should().NotThrow();
+        }
+
+        [TestMethod]
+        public void AnyReachedLimit_ShouldFalse()
+        {
+            var limiter1 = new TimeRateLimiter(TimeSpan.FromSeconds(10), 5);
+            var limiter2 = new TimeRateLimiter(TimeSpan.FromMinutes(1), 5);
+            var limiters = new LimitersList();
+            limiters.Add(limiter1);
+            limiters.Add(limiter2);
+            limiters.AnyReachedLimit().Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void AnyReachedLimit_ShouldTrueZeroAllowed()
+        {
+            var limiter1 = new TimeRateLimiter(TimeSpan.FromSeconds(10), 0);
+            var limiters = new LimitersList();
+            limiters.Add(limiter1);
+            limiters.AnyReachedLimit().Should().BeTrue();
+        }
+        
+        [TestMethod]
+        public void AnyReachedLimit_ShouldTrueRealLimit()
+        {
+            var limiter1 = new TimeRateLimiter(TimeSpan.FromSeconds(10), 5);
+            var limiter2 = new TimeRateLimiter(TimeSpan.FromMinutes(1), 5);
+            var limiters = new LimitersList();
+            limiters.Add(limiter1);
+            limiters.Add(limiter2);
+            for (int i = 0; i < 10; ++i)
+            {
+                limiters.NotifyAll(null, null);
+            }
+            limiters.AnyReachedLimit().Should().BeTrue();
+        }
+    }
+}

--- a/BlizzardApiReader.Core.Tests/Limiters/LimitersListTests.cs
+++ b/BlizzardApiReader.Core.Tests/Limiters/LimitersListTests.cs
@@ -10,7 +10,7 @@ namespace BlizzardApiReader.Core.Tests
     public class LimitersListTests
     {
         [TestMethod]
-        public void AddRemoveCases()
+        public void AddRemoveLimiters_TestCorrectExceptions()
         {
             var limiter1 = new TimeRateLimiter(TimeSpan.FromSeconds(10), 5);
             var limiter2 = new TimeRateLimiter(TimeSpan.FromMinutes(1), 5);
@@ -35,7 +35,7 @@ namespace BlizzardApiReader.Core.Tests
         }
 
         [TestMethod]
-        public void AnyReachedLimit_ShouldTrueZeroAllowed()
+        public void AnyReachedLimit_ShouldTrueZeroRequestsAllowed()
         {
             var limiter1 = new TimeRateLimiter(TimeSpan.FromSeconds(10), 0);
             var limiters = new LimitersList();
@@ -44,7 +44,7 @@ namespace BlizzardApiReader.Core.Tests
         }
         
         [TestMethod]
-        public void AnyReachedLimit_ShouldTrueRealLimit()
+        public void AnyReachedLimit_ShouldTrueRealLimitReached()
         {
             var limiter1 = new TimeRateLimiter(TimeSpan.FromSeconds(10), 5);
             var limiter2 = new TimeRateLimiter(TimeSpan.FromMinutes(1), 5);

--- a/BlizzardApiReader.Core.Tests/MockData/expiredTokenMock.json
+++ b/BlizzardApiReader.Core.Tests/MockData/expiredTokenMock.json
@@ -1,0 +1,5 @@
+{
+	"access_token": "TOKENGOESHERE",
+	"token_type": "bearer",
+	"expires_in": 0
+}

--- a/BlizzardApiReader.Core.Tests/Models/ApiConfigurationTests.cs
+++ b/BlizzardApiReader.Core.Tests/Models/ApiConfigurationTests.cs
@@ -8,8 +8,6 @@ namespace BlizzardApiReader.Core.Tests
     [TestClass]
     public class ApiConfigurationTests
     {
-        private readonly Locale defaultLocale;
-        private readonly Region defaultRegion;
 
         #region Constructor
         [TestMethod]
@@ -17,8 +15,8 @@ namespace BlizzardApiReader.Core.Tests
         {
             var configuration = new ApiConfiguration();
 
-            configuration.ApiRegion.Should().BeEquivalentTo(defaultRegion);
-            configuration.ResultLocale.Should().BeEquivalentTo(defaultLocale);
+            configuration.ApiRegion.Should().BeEquivalentTo(default(Region));
+            configuration.ResultLocale.Should().BeEquivalentTo(default(Locale));
             configuration.ClientId.Should().BeNull();
             configuration.ClientSecret.Should().BeNull();
         }
@@ -31,8 +29,8 @@ namespace BlizzardApiReader.Core.Tests
         {
             var config = ApiConfiguration.CreateDefault();
 
-            config.ApiRegion.Should().BeEquivalentTo(defaultRegion);
-            config.ResultLocale.Should().BeEquivalentTo(defaultLocale);
+            config.ApiRegion.Should().BeEquivalentTo(default(Region));
+            config.ResultLocale.Should().BeEquivalentTo(default(Locale));
             config.ClientId.Should().BeNull();
             config.ClientSecret.Should().BeNull();
         }
@@ -67,7 +65,7 @@ namespace BlizzardApiReader.Core.Tests
 
             config = config.SetRegion(Region.Korea);
             config.ApiRegion.Should().BeEquivalentTo(Region.Korea);
-            config.ResultLocale.Should().BeEquivalentTo(defaultLocale);
+            config.ResultLocale.Should().BeEquivalentTo(default(Locale));
         }
 
         #endregion
@@ -79,7 +77,7 @@ namespace BlizzardApiReader.Core.Tests
             var config = new ApiConfiguration();
 
             config = config.SetLocale(Locale.TraditionalChinese);
-            config.ApiRegion.Should().BeEquivalentTo(defaultRegion);
+            config.ApiRegion.Should().BeEquivalentTo(default(Region));
             config.ResultLocale.Should().BeEquivalentTo(Locale.TraditionalChinese);
         }
         #endregion

--- a/BlizzardApiReader.Core/ApiReader.cs
+++ b/BlizzardApiReader.Core/ApiReader.cs
@@ -15,7 +15,6 @@ namespace BlizzardApiReader.Core
         private static ApiConfiguration defaultConfig { get; set; }
         private static LimitersList limiters { get; } = new LimitersList();
 
-
         private ApiConfiguration _configuration;
         public ApiConfiguration Configuration
         {
@@ -23,7 +22,7 @@ namespace BlizzardApiReader.Core
             set
             {
                 _configuration = value;
-                _webClient = new ApiWebClient(_configuration);
+                _webClient = Configuration != null ? new ApiWebClient(Configuration) : null;
             }
         }
 
@@ -33,11 +32,11 @@ namespace BlizzardApiReader.Core
 
         public ApiReader(ApiConfiguration apiConfiguration = null, IWebClient webClient = null)
         {
-            _configuration = apiConfiguration;
-            if (webClient == null)
-                _webClient = new ApiWebClient(Configuration);
-            else
+            Configuration = apiConfiguration;
+            if (webClient != null)
+            {
                 _webClient = webClient;
+            }
         }
 
         public static void SetDefaultConfiguration(ApiConfiguration configuration)
@@ -98,7 +97,6 @@ namespace BlizzardApiReader.Core
 
         private void ThrowIfInvalidRequest()
         {
-
             VerifyConfigurationIsValid();
 
             if (limiters.AnyReachedLimit())
@@ -119,7 +117,7 @@ namespace BlizzardApiReader.Core
 
         private void VerifyConfigurationIsValid()
         {
-            if (Configuration == null)
+            if (Configuration == null || _webClient == null)
                 throw new NullReferenceException("ApiConfiguration is not set, either declare one as global configuration or set a local instance configuration object.");
         }
 

--- a/BlizzardApiReader.Core/ApiReader.cs
+++ b/BlizzardApiReader.Core/ApiReader.cs
@@ -9,7 +9,6 @@ namespace BlizzardApiReader.Core
 {
     public class ApiReader
     {
-        private const string url = "https://REGION.api.blizzard.com";
         /// <summary>
         /// Default configuration will be used if api reader does not have a local instance of ApiConfiguration
         /// </summary>
@@ -17,7 +16,16 @@ namespace BlizzardApiReader.Core
         private static LimitersList limiters { get; } = new LimitersList();
 
 
-        public ApiConfiguration Configuration;
+        private ApiConfiguration _configuration;
+        public ApiConfiguration Configuration
+        {
+            get { return _configuration ?? defaultConfig; }
+            set
+            {
+                _configuration = value;
+                _webClient = new ApiWebClient(_configuration);
+            }
+        }
 
         private IWebClient _webClient;
         private string _token;
@@ -25,9 +33,9 @@ namespace BlizzardApiReader.Core
 
         public ApiReader(ApiConfiguration apiConfiguration = null, IWebClient webClient = null)
         {
-            Configuration = apiConfiguration;
+            _configuration = apiConfiguration;
             if (webClient == null)
-                _webClient = new ApiWebClient();
+                _webClient = new ApiWebClient(Configuration);
             else
                 _webClient = webClient;
         }
@@ -44,15 +52,15 @@ namespace BlizzardApiReader.Core
 
         public async Task<T> GetAsync<T>(string query)
         {
-            throwIfInvalidRequest();
+            ThrowIfInvalidRequest();
 
             if (tokenExpired())
             {
                 await SendTokenRequest();
             }
 
-            string urlRequest = parseUrl(query);
-            IApiResponse response = await _webClient.MakeHttpRequestAsync(urlRequest);
+            string urlRequest = ParsePath(query);
+            IApiResponse response = await _webClient.MakeApiRequestAsync(urlRequest);
             limiters.NotifyAll(this, response);
 
             if (response.IsSuccessful())
@@ -73,7 +81,7 @@ namespace BlizzardApiReader.Core
         /// <returns></returns>
         public async Task<string> SendTokenRequest()
         {
-            var response = await _webClient.RequestAccessTokenAsync(getConfiguration());
+            var response = await _webClient.RequestAccessTokenAsync();
             if (response.IsSuccessful())
             {
                 string json = await response.ReadContentAsync();
@@ -88,14 +96,15 @@ namespace BlizzardApiReader.Core
         }
 
 
-        private void throwIfInvalidRequest()
+        private void ThrowIfInvalidRequest()
         {
 
-            verifyConfigurationIsValid();
+            VerifyConfigurationIsValid();
 
             if (limiters.AnyReachedLimit())
                 throw new RateLimitReachedException("http request was blocked by RateLimiter");
         }
+
         private bool tokenExpired()
         {
             if (String.IsNullOrEmpty(_token)
@@ -108,36 +117,26 @@ namespace BlizzardApiReader.Core
         }
 
 
-        private void verifyConfigurationIsValid()
+        private void VerifyConfigurationIsValid()
         {
-            if (getConfiguration() == null)
+            if (Configuration == null)
                 throw new NullReferenceException("ApiConfiguration is not set, either declare one as global configuration or set a local instance configuration object.");
         }
 
 
-        private string parseUrl(string query)
+        private string ParsePath(string query)
         {
-            query = parseSpecialCharacters(query);
-
-            string region = getConfiguration().GetRegionString();
-            string newUrl = url.Replace("REGION", region.ToLower());
-            newUrl += query + "?locale=" + getConfiguration().GetLocaleString() + "&access_token=" + _token;
-            return newUrl;
+            return ParseSpecialCharacters(query) 
+                + "?locale=" + Configuration.GetLocaleString() 
+                + "&access_token=" + _token;
         }
 
 
 
-        private string parseSpecialCharacters(string s)
+        private string ParseSpecialCharacters(string s)
         {
             s = s.Replace("#", "%23");
             return s;
-        }
-        private ApiConfiguration getConfiguration()
-        {
-            if (Configuration == null)
-                return defaultConfig;
-            else
-                return Configuration;
         }
     }
 }

--- a/BlizzardApiReader.Core/ApiReader.cs
+++ b/BlizzardApiReader.Core/ApiReader.cs
@@ -53,7 +53,7 @@ namespace BlizzardApiReader.Core
         {
             ThrowIfInvalidRequest();
 
-            if (tokenExpired())
+            if (TokenExpired())
             {
                 await SendTokenRequest();
             }
@@ -103,9 +103,9 @@ namespace BlizzardApiReader.Core
                 throw new RateLimitReachedException("http request was blocked by RateLimiter");
         }
 
-        private bool tokenExpired()
+        private bool TokenExpired()
         {
-            if (String.IsNullOrEmpty(_token)
+            if (string.IsNullOrEmpty(_token)
                 || DateTime.Now > _tokenExpiration)
             {
                 return true;

--- a/BlizzardApiReader.Core/Models/ApiConfiguration.cs
+++ b/BlizzardApiReader.Core/Models/ApiConfiguration.cs
@@ -11,8 +11,14 @@ namespace BlizzardApiReader.Core
         public string ClientId;
         public string ClientSecret;
 
+        private const string AUTH_URL_TEMPLATE = "https://REGION.battle.net/oauth/token";
+        private const string API_URL_TEMPLATE = "https://REGION.api.blizzard.com";
+        private string authUrl = string.Empty;
+        private string apiUrl = string.Empty;
+
         public ApiConfiguration()
         {
+            SetRegion(Region.Europe, true);
             ResultLocale = ApiRegion.GetDefaultLocale();
         }
        
@@ -48,6 +54,8 @@ namespace BlizzardApiReader.Core
         public ApiConfiguration SetRegion(Region region, bool useDefaultLocale)
         {
             ApiRegion = region;
+            apiUrl = API_URL_TEMPLATE.Replace("REGION", GetRegionString());
+            authUrl = AUTH_URL_TEMPLATE.Replace("REGION", GetRegionString());
             if (useDefaultLocale)
             {
                 ResultLocale = region.GetDefaultLocale();
@@ -74,9 +82,20 @@ namespace BlizzardApiReader.Core
         {
             return ResultLocale.GetEnumValue();
         }
+
         public string GetRegionString()
         {
             return ApiRegion.GetEnumValue();
+        }
+
+        public string GetAuthUrl()
+        {
+            return authUrl;
+        }
+
+        public string GetApiUrl()
+        {
+            return apiUrl;
         }
     }
 }

--- a/BlizzardApiReader.Core/Models/ApiWebClient.cs
+++ b/BlizzardApiReader.Core/Models/ApiWebClient.cs
@@ -17,7 +17,7 @@ namespace BlizzardApiReader.Core
 
         public ApiWebClient(ApiConfiguration configuration)
         {
-            _configuration = configuration ?? throw new NullReferenceException("ApiConfiguration is not set, either declare one as global configuration or set a local instance configuration object."); ;
+            _configuration = configuration;
             var jsonHeader = new MediaTypeWithQualityHeaderValue("application/json");
             _apiClient = new HttpClient();
             _apiClient.DefaultRequestHeaders.Accept.Clear();

--- a/BlizzardApiReader.Core/Models/IWebClient.cs
+++ b/BlizzardApiReader.Core/Models/IWebClient.cs
@@ -4,10 +4,7 @@ namespace BlizzardApiReader.Core
 {
     public interface IWebClient
     {
-
-        Task<IApiResponse> MakeHttpRequestAsync(string query);
-
-        Task<IApiResponse> RequestAccessTokenAsync(ApiConfiguration configuration);
-
+        Task<IApiResponse> MakeApiRequestAsync(string path);
+        Task<IApiResponse> RequestAccessTokenAsync();
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.com/oliverkovac/BlizzardApiReader.svg?branch=master)](https://travis-ci.com/oliverkovac/BlizzardApiReader)
+
 # Blizzard ApiReader
 C# .net Core library wrapper for Blizzard Public APIs
 


### PR DESCRIPTION
I've changed ApiWebClient to reuse the HttpClient (see i.e. https://aspnetmonsters.com/2016/08/2016-08-27-httpclientwrong/) which to my surprise considerably increased the performance of sending multiple requests in a row.

Given these changes I had to modify the structure of other classes, such as moving URLs to Configuration and letting it create them based on configured regions, etc. Also ApiReader now only sends the path and query to the WebClient which appends them to the API domain.

I've also added a few tests, mostly useless ones just to increase coverage. Also I've tested a TravisCI integration on my fork, which seems to work well, so if interested feel free to use it, just gotta integrate this repository in TravisCI and edit a few paths which at the moment refer to the fork.

I know this is quite big and I should probably split it into smaller requests, but initially I just planned to toy around and experiment a bit more in my fork and ended up finding the thing about HttpClient, so I had to let you guys know!