### PR TITLE
Add proxy capabilities and move conection lifetime to api configuration

### DIFF
--- a/BlizzardApiReader.Core/Models/ApiConfiguration.cs
+++ b/BlizzardApiReader.Core/Models/ApiConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿using BlizzardApiReader.Core.Enums;
 using BlizzardApiReader.Core.Extensions;
 using System;
+using System.Net;
 
 namespace BlizzardApiReader.Core
 {
@@ -15,6 +16,9 @@ namespace BlizzardApiReader.Core
         private const string API_URL_TEMPLATE = "https://REGION.api.blizzard.com";
         private string authUrl = string.Empty;
         private string apiUrl = string.Empty;
+
+        private WebProxy _WebProxy=null;
+        private TimeSpan _PooledConnectionLifetime = TimeSpan.FromMinutes(1);
 
         public ApiConfiguration()
         {
@@ -39,7 +43,7 @@ namespace BlizzardApiReader.Core
             ClientSecret = clientSecret;
             return this;
         }
-
+                
         public ApiConfiguration SetRegion(Region region)
         {
             return SetRegion(region, false);
@@ -70,6 +74,39 @@ namespace BlizzardApiReader.Core
         }
 
         /// <summary>
+        /// Set the http proxy to use on all the calls, by default is not configured (null) and to remove it you need to call it to with ""
+        /// </summary>
+        /// <param name="proxy">URL with the proxy to use, for example http://server:port </param>        
+        /// <returns>This instance of ApiConfiguration</returns>
+        public ApiConfiguration SetHttpProxy(string proxy)
+        {
+            if (proxy == "")
+            {
+                _WebProxy = null;
+            }
+            else {
+                _WebProxy = new WebProxy()
+                {
+                    Address = new Uri(proxy),
+                    UseDefaultCredentials = true
+                };
+            }
+            
+            return this;
+        }
+
+        /// <summary>
+        /// Configure the lifetime of the connection for refreshing DNS queries, by default is 1 minute
+        /// </summary>
+        /// <param name="pooledConnectionLifetime">Lifetime in minutes</param>        
+        /// <returns>This instance of ApiConfiguration</returns>
+        public ApiConfiguration SetPooledConnectionLifetime(int pooledConnectionLifetime)
+        {
+            _PooledConnectionLifetime = TimeSpan.FromMinutes(pooledConnectionLifetime);
+            return this;
+        }
+
+        /// <summary>
         /// Declare this Configuration as the global default configuration, it will be used when no configuration is provided to the api reader.
         /// </summary>  
         public ApiConfiguration DeclareAsDefault()
@@ -96,6 +133,15 @@ namespace BlizzardApiReader.Core
         public string GetApiUrl()
         {
             return apiUrl;
+        }
+
+        public WebProxy GetHttpProxy()
+        {
+            return _WebProxy;
+        }
+        public TimeSpan GetPooledConnectionLifetime()
+        {
+            return _PooledConnectionLifetime;
         }
     }
 }


### PR DESCRIPTION
I dont think that many people will need this, as most of the usage will be on the internet already, but adding the functionality was not that big and if someone needs to access from behind a corporate firewall this will allow it easilly. If I want to check something from the office, I will need it anyway.

Also I moved the 1 minute lifetime to the configuration and remove the hardcoded one, just in case we need to change to another value in the future.