### PR TITLE
Adding Character and Guild APIs for WOW

### DIFF
--- a/BlizzardApiReader.Core/ApiReader.cs
+++ b/BlizzardApiReader.Core/ApiReader.cs
@@ -57,7 +57,7 @@ namespace BlizzardApiReader.Core
             defaultConfig = null;
         }
 
-        public async Task<T> GetAsync<T>(string query)
+        public async Task<T> GetAsync<T>(string query, string additionalParams=null)
         {
             throwIfInvalidRequest();
 
@@ -66,7 +66,7 @@ namespace BlizzardApiReader.Core
                 await SendTokenRequest();
             }
 
-            string urlRequest = parsePath(query);
+            string urlRequest = parsePath(query,additionalParams);
             IApiResponse response = await _webClient.MakeApiRequestAsync(Configuration.GetApiUrl() + urlRequest);
             limiters.NotifyAll(this, response);
 
@@ -130,11 +130,22 @@ namespace BlizzardApiReader.Core
         }
 
 
-        private string parsePath(string query)
+        private string parsePath(string query, string addtionalParams=null)
         {
-            return parseSpecialCharacters(query) 
-                + "?locale=" + Configuration.GetLocaleString() 
+            if (addtionalParams is null)
+            {
+                return parseSpecialCharacters(query)
+                + "?locale=" + Configuration.GetLocaleString()
                 + "&access_token=" + _token;
+            }
+            else
+            {
+                return parseSpecialCharacters(query)
+                + "?locale=" + Configuration.GetLocaleString()
+                + "&access_token=" + _token
+                + addtionalParams;
+            }
+        
         }
 
 

--- a/BlizzardApiReader.WorldOfWarcraft/Models/Achievement.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/Achievement.cs
@@ -13,7 +13,7 @@ namespace BlizzardApiReader.WorldOfWarcraft.Models
         public int Points { get; set; }
         public string Description { get; set; }
         public string Reward { get; set; }
-        public RewardItem[] RewardItems { get; set; }
+        public CharacterItem[] RewardItems { get; set; }
         public string Icon { get; set; }
         public Criteria[] Criteria { get; set; }
         public bool AccountWide { get; set; }

--- a/BlizzardApiReader.WorldOfWarcraft/Models/Achievements.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/Achievements.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BlizzardApiReader.WorldOfWarcraft.Models
+{
+    public class Achievements
+    {
+        public int[] AchievementsCompleted { get; set; }
+
+        public long[] AchievementsCompletedTimestamp { get; set; }
+
+        public int[] Criteria { get; set; }
+
+        public long[] CriteriaQuantity { get; set; }
+        public long[] CriteriaTimestamp { get; set; }
+
+        public long[] CriteriaCreated { get; set; }
+
+    }
+}

--- a/BlizzardApiReader.WorldOfWarcraft/Models/ArtifactTrait.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/ArtifactTrait.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BlizzardApiReader.WorldOfWarcraft.Models
+{
+    public class ArtifactTrait
+    {
+        public int Id { get; set; }
+        public int Rank { get; set; }        
+    }
+}

--- a/BlizzardApiReader.WorldOfWarcraft/Models/AzeriteEmpoweredItem.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/AzeriteEmpoweredItem.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BlizzardApiReader.WorldOfWarcraft.Models
+{
+    public class AzeriteEmpoweredItem
+    {
+        public AzeritePower[] AzeritePowers { get; set; }
+        
+    }
+}

--- a/BlizzardApiReader.WorldOfWarcraft/Models/AzeriteItem.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/AzeriteItem.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BlizzardApiReader.WorldOfWarcraft.Models
+{
+    public class AzeriteItem
+    {
+        public int AzeriteLevel { get; set; }
+        public int AzeriteExperience { get; set; }
+        public int AzeriteExperienceRemaining { get; set; }        
+    }
+}

--- a/BlizzardApiReader.WorldOfWarcraft/Models/AzeritePower.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/AzeritePower.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BlizzardApiReader.WorldOfWarcraft.Models
+{
+    public class AzeritePower
+    {
+        public int Id { get; set; }
+        public int Tier { get; set; }
+        public int SpellId { get; set; }
+        public int BonusListId { get; set; }
+    }
+}

--- a/BlizzardApiReader.WorldOfWarcraft/Models/Character.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/Character.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -20,11 +22,7 @@ namespace BlizzardApiReader.WorldOfWarcraft.Models
         public string Thumbnail { get; set; }
 
         public Spec Spec { get; set; }
-
-        public string Guild { get; set; }
-
-        public string GuildRealm { get; set; }
-
+                
         //TODO: Review format, sometimes comes with a value of 0, sometimes with >0
         //TODO: Look for which format is used and how to deal with the 0 values.
         public string LastModified { get; set; }
@@ -37,5 +35,92 @@ namespace BlizzardApiReader.WorldOfWarcraft.Models
 
         public int TotalHonorableKills { get; set; }
 
+        //Extended Information that can be requested optionaly
+
+        //Field=achievements
+        public Achievements Achievements { get; set; }
+
+        //Field=appearance
+        public CharacterAppearance Appearance { get; set; }
+
+        //Field=feed
+        public CharacterFeedItem[] Feed { get; set; }
+
+        //Field=guild
+        [JsonProperty("guild")]
+        [JsonConverter(typeof(GuildConverter))]
+        public CharacterGuild Guild { get; set; }
+
+        /* TODO: Review how can we get the guild when it comes as a name (string) instead as an object and put in other property
+        [JsonProperty("guild")]        
+        public string Guild { get; set; }        
+
+        public string GuildRealm { get; set; }
+        */
+        
+        //Field=hunterPets
+        public HunterPet[] HunterPets { get; set; }
+
+        //Field=items
+        public CharacterItems Items { get; set; }
+        
+        //Field=mounts
+        public CharacterMounts Mounts { get; set; }
+        
+        //Field=pets
+        public CharacterPets Pets { get; set; }
+
+        //Field=petSlots
+        public CharacterPetSlot[] PetSlots { get; set; }
+
+        //Field=professions
+        public CharacterProfessions Professions { get; set; }
+
+        //Field=progression
+        public CharacterProgression Progression { get; set; }
+
+        //Field=pvp
+        public CharacterPvp Pvp { get; set; }
+
+        //Field=quests
+        public int[] Quests { get; set; }
+
+        //Field=reputation
+        public CharacterReputation[] Reputation { get; set; }
+
+        //Field=statistics
+        public CharacterSubCategories Statistics { get; set; }
+
+        //Field=stats
+        public CharacterStats Stats { get; set; }
+
+        //Field=talents
+        public CharacterTalent[] Talents { get; set; }
+
+        //Field=titles
+        public CharacterTitle[] Titles { get; set; }
+    }
+
+    class GuildConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return (objectType == typeof(CharacterGuild));
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            JToken token = JToken.Load(reader);
+            if (token.Type == JTokenType.Object)
+            {
+                return token.ToObject<CharacterGuild>();
+            }
+            return null;
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            serializer.Serialize(writer, value);
+        }
     }
 }

--- a/BlizzardApiReader.WorldOfWarcraft/Models/CharacterAppearance.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/CharacterAppearance.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BlizzardApiReader.WorldOfWarcraft.Models
+{
+    public class CharacterAppearance
+    {
+        public int FaceVariation { get; set; }
+        public int SkinColor { get; set; }
+        public int HairVariation { get; set; }
+        public int HairColor { get; set; }
+        public int FeatureVariation { get; set; }
+        public bool ShowHelm { get; set; }
+        public bool ShowCloak { get; set; }
+        public int[] CustomDisplayOptions { get; set; }
+    }
+}

--- a/BlizzardApiReader.WorldOfWarcraft/Models/CharacterFeedItem.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/CharacterFeedItem.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BlizzardApiReader.WorldOfWarcraft.Models
+{
+    public class CharacterFeedItem
+    {
+        //Type: ACHIEVEMENT
+        public string Type { get; set; }
+        //TODO: Review the formating of timestamp
+        public long Timestamp { get; set; }
+        public Achievement Achievement { get; set; }
+        public bool FeatOfStrength { get; set; }
+
+        //Type: CRITERIA
+        public Criteria Criteria { get; set; }
+
+        //Type: BOSSKILL
+        public int Quantity { get; set; }
+        public string Name { get; set; }
+
+        //Type: LOOT
+        public int ItemId { get; set; }
+        public string context { get; set; }
+        public int[] BonusLists { get; set; }
+
+    }
+}

--- a/BlizzardApiReader.WorldOfWarcraft/Models/CharacterGuild.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/CharacterGuild.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BlizzardApiReader.WorldOfWarcraft.Models
+{
+    public class CharacterGuild
+    {
+        public string Name { get; set; }
+        public string Realm { get; set; }
+        public string BattleGroup { get; set; }
+        public int Members { get; set; }
+        public int AchievementPoints { get; set; }
+        public GuildEmblem Emblem { get; set; }
+    }
+}

--- a/BlizzardApiReader.WorldOfWarcraft/Models/CharacterItem.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/CharacterItem.cs
@@ -1,28 +1,29 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace BlizzardApiReader.WorldOfWarcraft.Models
 {
-    public class RewardItem
+    public class CharacterItem
     {
         public int Id { get; set; }
         public string Name { get; set; }
         public string Icon { get; set; }
         public int Quality { get; set; }
-        public int ItemLevel { get; set; }
         public TooltipParams TooltipParams { get; set; }
-        public object[] Stats { get; set; }
+        public ItemStat[] Stats { get; set; }
         public int Armor { get; set; }
+        public WeaponInfo WeaponInfo { get; set; }
         public string Context { get; set; }
-        public object[] BonusLists { get; set; }
+        public int[] BonusLists { get; set; }
         public int DisplayInfoId { get; set; }
         public int ArtifactId { get; set; }
         public int ArtifactAppearanceId { get; set; }
-        public object[] ArtifactTraits { get; set; }
-        public object[] Relics { get; set; }
-        public object Appearance { get; set; }
+        public ArtifactTrait[] ArtifactTraits { get; set; }
+        public Relic[] Relics { get; set; }
+        public ItemAppearance Appearance { get; set; }
+        public AzeriteItem AzeriteItem { get; set; }
+        public AzeriteEmpoweredItem AzeriteEmpoweredItem { get; set; }
+
     }
 }

--- a/BlizzardApiReader.WorldOfWarcraft/Models/CharacterItems.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/CharacterItems.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BlizzardApiReader.WorldOfWarcraft.Models
+{
+    public class CharacterItems
+    {
+        public int AverageItemLevel { get; set; }
+        public int AverageItemLevelEquipped { get; set; }
+        public CharacterItem Head { get; set; }
+        public CharacterItem Neck { get; set; }
+        public CharacterItem Shoulder { get; set; }
+        public CharacterItem Back { get; set; }
+        public CharacterItem Chest { get; set; }
+        public CharacterItem Shirt { get; set; }
+        public CharacterItem Tabard { get; set; }
+        public CharacterItem Wrist { get; set; }
+        public CharacterItem Hands { get; set; }
+        public CharacterItem Waist { get; set; }
+        public CharacterItem Legs { get; set; }
+        public CharacterItem Feet { get; set; }
+        public CharacterItem Finger1 { get; set; }
+        public CharacterItem Finger2 { get; set; }
+        public CharacterItem Trinket1 { get; set; }
+        public CharacterItem Trinket2 { get; set; }
+        public CharacterItem MainHand { get; set; }
+
+    }
+}

--- a/BlizzardApiReader.WorldOfWarcraft/Models/CharacterMounts.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/CharacterMounts.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BlizzardApiReader.WorldOfWarcraft.Models
+{
+    public class CharacterMounts
+    {
+        public int NumCollected { get; set; }
+        public int NumNotCollected { get; set; }
+        public Mount[] Collected { get; set; }
+       
+    }
+}

--- a/BlizzardApiReader.WorldOfWarcraft/Models/CharacterPetSlot.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/CharacterPetSlot.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BlizzardApiReader.WorldOfWarcraft.Models
+{
+    public class CharacterPetSlot
+    {        
+        public int Slot { get; set; }
+        public string BattlePetGuid { get; set; }
+        public bool IsEmpty { get; set; }
+        public bool IsLocked { get; set; }
+        public int[] Abilities { get; set; }
+        
+    }
+}

--- a/BlizzardApiReader.WorldOfWarcraft/Models/CharacterPets.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/CharacterPets.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BlizzardApiReader.WorldOfWarcraft.Models
+{
+    public class CharacterPets
+    {
+        public int NumCollected { get; set; }
+        public int NumNotCollected { get; set; }
+        public Pet[] Collected { get; set; }
+       
+    }
+}

--- a/BlizzardApiReader.WorldOfWarcraft/Models/CharacterProfessions.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/CharacterProfessions.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BlizzardApiReader.WorldOfWarcraft.Models
+{
+    public class CharacterProfessions
+    {
+        public Profession[] Primary { get; set; }
+        public Profession[] Secondary { get; set; }
+        
+       
+    }
+}

--- a/BlizzardApiReader.WorldOfWarcraft/Models/CharacterProgression.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/CharacterProgression.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BlizzardApiReader.WorldOfWarcraft.Models
+{
+    public class CharacterProgression
+    {
+        public CharacterRaidProgression[] Raids { get; set; }                       
+    }
+}

--- a/BlizzardApiReader.WorldOfWarcraft/Models/CharacterPvp.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/CharacterPvp.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BlizzardApiReader.WorldOfWarcraft.Models
+{
+    public class CharacterPvp
+    {
+        public CharacterPvpBrackets Brackets { get; set; }        
+       
+    }
+}

--- a/BlizzardApiReader.WorldOfWarcraft/Models/CharacterPvpBracket.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/CharacterPvpBracket.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BlizzardApiReader.WorldOfWarcraft.Models
+{
+    public class CharacterPvpBracket
+    {
+        public string Slug { get; set; }
+        public int Rating { get; set; }
+        public int WeeklyPlayed { get; set; }
+        public int WeeklyWon { get; set; }
+        public int WeeklyLost { get; set; }
+        public int SeasonPlayed { get; set; }
+        public int seasonWon { get; set; }
+        public int SeasonLost { get; set; }
+        public int Tier { get; set; }
+    }
+}

--- a/BlizzardApiReader.WorldOfWarcraft/Models/CharacterPvpBrackets.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/CharacterPvpBrackets.cs
@@ -1,0 +1,20 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BlizzardApiReader.WorldOfWarcraft.Models
+{
+    public class CharacterPvpBrackets
+    {
+        [JsonProperty("Arena_Bracket_2v2")]
+        public CharacterPvpBracket ArenaBracket2v2 { get; set; }
+        [JsonProperty("Arena_Bracket_3v3")]
+        public CharacterPvpBracket ArenaBracket3v3 { get; set; }
+        [JsonProperty("Arena_Bracket_RGB")]
+        public CharacterPvpBracket ArenaBracketRBG { get; set; }
+        [JsonProperty("Arena_Bracket_2v2_Skirmish")]
+        public CharacterPvpBracket ArenaBracket2v2Skirmish { get; set; }
+        public CharacterPvpBracket Unknown { get; set; }
+    }
+}

--- a/BlizzardApiReader.WorldOfWarcraft/Models/CharacterRaidBossProgression.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/CharacterRaidBossProgression.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BlizzardApiReader.WorldOfWarcraft.Models
+{
+    public class CharacterRaidBossProgression
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public int LfrKills { get; set; }
+        public long LfrTimestamp { get; set; }
+        public int NormalKills { get; set; }
+        public long NormalTimestamp { get; set; }
+        public int HeroicKills { get; set; }
+        public long HeroicTimestamp { get; set; }
+        public int MythicKills { get; set; }
+        public long MythicTimestamp { get; set; }
+
+    }
+}

--- a/BlizzardApiReader.WorldOfWarcraft/Models/CharacterRaidProgression.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/CharacterRaidProgression.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BlizzardApiReader.WorldOfWarcraft.Models
+{
+    public class CharacterRaidProgression
+    {
+        public string Name { get; set; }
+        public int Lfr { get; set; }
+        public int Normal { get; set; }
+        public int Heroic { get; set; }
+        public int Mythic { get; set; }
+        public int Id { get; set; }
+        public CharacterRaidBossProgression[] Bosses { get; set; }        
+    }
+}

--- a/BlizzardApiReader.WorldOfWarcraft/Models/CharacterReputation.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/CharacterReputation.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BlizzardApiReader.WorldOfWarcraft.Models
+{
+    public class CharacterReputation
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public int Standing { get; set; }
+        public int Value { get; set; }
+        public int Max { get; set; }
+        
+    }
+}

--- a/BlizzardApiReader.WorldOfWarcraft/Models/CharacterStatistics.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/CharacterStatistics.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BlizzardApiReader.WorldOfWarcraft.Models
+{
+    public class CharacterStatistics
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public long Quantity { get; set; }
+        //TODO: Date format
+        public long LastUpdated { get; set; }
+        public bool Money { get; set; }
+
+    }
+}

--- a/BlizzardApiReader.WorldOfWarcraft/Models/CharacterStats.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/CharacterStats.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BlizzardApiReader.WorldOfWarcraft.Models
+{
+    public class CharacterStats
+    {
+        public int Health { get; set; }
+        public string PowerType { get; set; }
+        public int Power { get; set; }
+        public int Str { get; set; }
+        public int Agi { get; set; }
+        public int Int { get; set; }
+        public int Sta { get; set; }
+        public double SpeedRating { get; set; }
+        public double SpeedRatingBonus { get; set; }
+        public double Crit { get; set; }
+        public int CritRating { get; set; }
+        public double Haste { get; set; }
+        public int HasteRating { get; set; }
+        public double HasteRatingPercent { get; set; }
+        public double Mastery { get; set; }
+        public int MasteryRating { get; set; }
+        public double Leech { get; set; }
+        public double LeechRating { get; set; }
+        public double LeechRatingBonus { get; set; }
+        public int Versatility { get; set; }
+        public double VersatilityDamageDoneBonus { get; set; }
+        public double VersatilityHealingDoneBonus { get; set; }
+        public double VersatilityDamageTakenBonus { get; set; }
+        public double AvoidanceRating { get; set; }
+        public double AvoidanceRatingBonus { get; set; }
+        public double SpellPen { get; set; }
+        public double SpellCrit { get; set; }
+        public int SpellCritRating { get; set; }
+        public double Mana5 { get; set; }
+        public double Mana5Combat { get; set; }
+        public int Armor { get; set; }
+        public double Dodge { get; set; }
+        public int DodgeRating { get; set; }
+        public double Parry { get; set; }
+        public int ParryRating { get; set; }
+        public double Block { get; set; }
+        public int BlockRating { get; set; }
+        public double MainHandDmgMin { get; set; }
+        public double MainHandDmgMax { get; set; }
+        public double MainHandSpeed { get; set; }
+        public double MainHandDps { get; set; }
+        public double OffHandDmgMin { get; set; }
+        public double OffHandDmgMax { get; set; }
+        public double OffHandSpeed { get; set; }
+        public double OffHandDps { get; set; }
+        public double RangedDmgMin { get; set; }
+        public double RangedDmgMax { get; set; }
+        public double RangedSpeed { get; set; }
+        public double RangedDps { get; set; }
+    }
+}

--- a/BlizzardApiReader.WorldOfWarcraft/Models/CharacterSubCategories.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/CharacterSubCategories.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BlizzardApiReader.WorldOfWarcraft.Models
+{
+    public class CharacterSubCategories
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public CharacterSubCategories[] SubCategories { get; set; }
+        public CharacterStatistics[] Statistics { get; set; }
+
+    }
+}

--- a/BlizzardApiReader.WorldOfWarcraft/Models/CharacterTalent.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/CharacterTalent.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BlizzardApiReader.WorldOfWarcraft.Models
+{
+    public class CharacterTalent
+    {
+        public bool Selected { get; set; }
+        public Talent[] Talents { get; set; }
+        public Spec Spec { get; set; }
+        public string CalcTalent { get; set; }
+        public string CalcSpec { get; set; }
+    }
+}

--- a/BlizzardApiReader.WorldOfWarcraft/Models/CharacterTitle.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/CharacterTitle.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BlizzardApiReader.WorldOfWarcraft.Models
+{
+    public class CharacterTitle
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }        
+    }
+}

--- a/BlizzardApiReader.WorldOfWarcraft/Models/Guild.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/Guild.cs
@@ -1,0 +1,28 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BlizzardApiReader.WorldOfWarcraft.Models
+{
+    public class Guild
+    {
+        public string Name { get; set; }
+        public string Realm { get; set; }
+        public string BattleGroup { get; set; }
+        public int AchievementPoints { get; set; }
+        public GuildEmblem Emblem { get; set; }
+
+        public int Level { get; set; }
+        public int Side { get; set; }
+             
+        public GuildMember[] Members { get; set; }
+
+        //Field=achievements
+        public Achievements Achievements { get; set; }
+
+        //Field=news
+        public GuildNewsItem[] News { get; set; }
+    }    
+}

--- a/BlizzardApiReader.WorldOfWarcraft/Models/GuildEmblem.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/GuildEmblem.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BlizzardApiReader.WorldOfWarcraft.Models
+{
+    public class GuildEmblem
+    {
+        public int Icon { get; set; }
+        public string IconColor { get; set; }
+        public int IconColorId { get; set; }
+        public int Border { get; set; }
+        public string BorderColor { get; set; }
+        public int BorderColorId { get; set; }
+        public string BackgroundColor { get; set; }
+        public int BackgroundColorId { get; set; }
+
+    }
+}

--- a/BlizzardApiReader.WorldOfWarcraft/Models/GuildMember.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/GuildMember.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BlizzardApiReader.WorldOfWarcraft.Models
+{
+    public class GuildMember
+    {        
+        public Character Character { get; set; }        
+        public int Rank { get; set; }        
+    }
+}

--- a/BlizzardApiReader.WorldOfWarcraft/Models/GuildNewsItem.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/GuildNewsItem.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BlizzardApiReader.WorldOfWarcraft.Models
+{
+    public class GuildNewsItem
+    {
+        
+        public string Type { get; set; }
+        public string Character { get; set; }
+
+        //TODO: Review the formating of timestamp
+        public long Timestamp { get; set; }
+        public string context { get; set; }
+        public int[] BonusLists { get; set; }
+        
+        //Type: playerAchievement
+        public Achievement Achievement { get; set; }
+
+        //Type: itemLoot, itemPurchase, itemCraft
+        public int ItemId { get; set; }
+    }
+}

--- a/BlizzardApiReader.WorldOfWarcraft/Models/HunterPet.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/HunterPet.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BlizzardApiReader.WorldOfWarcraft.Models
+{
+    public class HunterPet
+    {        
+        public string Name { get; set; }
+        public int Creature { get; set; }
+        public int Slot { get; set; }
+        public Spec Spec { get; set; }
+        public string CalcSpec { get; set; }
+        public int FamilyId { get; set; }
+        public string FamilyName { get; set; }
+        public bool Selected { get; set; }
+        
+    }
+}

--- a/BlizzardApiReader.WorldOfWarcraft/Models/ItemAppearance.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/ItemAppearance.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BlizzardApiReader.WorldOfWarcraft.Models
+{
+    public class ItemAppearance
+    {
+        public int ItemId { get; set; }
+        public int ItemAppearanceModId { get; set; }
+        public int TransmogItemAppearanceModId { get; set; }        
+    }
+}

--- a/BlizzardApiReader.WorldOfWarcraft/Models/ItemStat.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/ItemStat.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BlizzardApiReader.WorldOfWarcraft.Models
+{
+    public class ItemStat
+    {
+        public int Stat { get; set; }
+        public int Amount { get; set; }        
+    }
+}

--- a/BlizzardApiReader.WorldOfWarcraft/Models/Pet.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/Pet.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BlizzardApiReader.WorldOfWarcraft.Models
+{
+    public class Pet
+    {
+        public string Name { get; set; }
+        public int SpellId { get; set; }
+        public int CreatureId { get; set; }
+        public int ItemId { get; set; }
+        public int QualityId { get; set; }
+        public string Icon { get; set; }
+        public PetStats Stats { get; set; }
+        public string BattlePetGuid { get; set; }
+        public bool IsFavorite { get; set; }
+        public bool IsFirstAbilitySlotSelected { get; set; }
+        public bool IsSecondAbilitySlotSelected { get; set; }
+        public bool IsThirdAbilitySlotSelected { get; set; }
+        public string CreatureName { get; set; }
+        public bool CanBattle { get; set; }
+    }
+}

--- a/BlizzardApiReader.WorldOfWarcraft/Models/PetStats.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/PetStats.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BlizzardApiReader.WorldOfWarcraft.Models
+{
+    public class PetStats
+    {        
+        public int SpeciesId { get; set; }
+        public int BreedId { get; set; }
+        public int PetQualityId { get; set; }
+        public int Level { get; set; }
+        public int Health { get; set; }
+        public int Power { get; set; }
+        public int Speed { get; set; }
+        
+    }
+}

--- a/BlizzardApiReader.WorldOfWarcraft/Models/Profession.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/Profession.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BlizzardApiReader.WorldOfWarcraft.Models
+{
+    public class Profession
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public string Icon { get; set; }
+        public int Rank { get; set; }
+        public int Max { get; set; }
+        public int[] Recipes { get; set; }
+        
+    }
+}

--- a/BlizzardApiReader.WorldOfWarcraft/Models/Relic.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/Relic.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BlizzardApiReader.WorldOfWarcraft.Models
+{
+    public class Relic
+    {
+        public int Socket { get; set; }
+        public int ItemId { get; set; }
+        public int context { get; set; }
+        public int[] BonusLists { get; set; }        
+    }
+}

--- a/BlizzardApiReader.WorldOfWarcraft/Models/Talent.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/Talent.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BlizzardApiReader.WorldOfWarcraft.Models
+{
+    public class Talent
+    {
+        public int Tier { get; set; }
+        public int Column { get; set; }
+        public Spell Spell { get; set; }
+        public Spec Spec { get; set; }
+    }
+}

--- a/BlizzardApiReader.WorldOfWarcraft/Models/WeaponInfo.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/Models/WeaponInfo.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BlizzardApiReader.WorldOfWarcraft.Models
+{
+    public class WeaponInfo
+    {
+        public Damage Damage { get; set; }
+        public double WeaponSpeed { get; set; }
+        public double Dps { get; set; }        
+    }
+
+    public class Damage
+    {
+        public int Min { get; set; }
+        public int Max { get; set; }
+        public double ExactMin { get; set; }
+        public double ExactMax { get; set; }
+    }
+}

--- a/BlizzardApiReader.WorldOfWarcraft/WorldOfWarcraftApi.cs
+++ b/BlizzardApiReader.WorldOfWarcraft/WorldOfWarcraftApi.cs
@@ -94,13 +94,40 @@ namespace BlizzardApiReader.WorldOfWarcraft
         #endregion
 
         #region Character Profile
-        public async Task<Character> GetCharacterAsync(string realm, string characterName)
+        public async Task<Character> GetCharacterAsync(string realm, string characterName, string fields=null)
         {
             string query = $"/wow/character/{realm}/{characterName}";
-            return await reader.GetAsync<Character>(query);
+
+            if (fields is null)
+            {            
+                return await reader.GetAsync<Character>(query);
+            } else
+            {
+                return await reader.GetAsync<Character>(query,"&fields="+fields);
+            }
         }
 
 
-        #endregion 
+
+        #endregion
+
+        #region Guild Profile
+        public async Task<Guild> GetGuildAsync(string realm, string guildName, string fields = null)
+        {
+            string query = $"/wow/guild/{realm}/{guildName}";
+
+            if (fields is null)
+            {
+                return await reader.GetAsync<Guild>(query);
+            }
+            else
+            {
+                return await reader.GetAsync<Guild>(query, "&fields=" + fields);
+            }
+        }
+
+        //TODO Members, Achievements, News Challenge
+
+        #endregion
     }
 }


### PR DESCRIPTION
Adding WOW missing APIs, on Character and Guild. There are still a few more APIs missing, but this will allow 90% of the most needed ones.

I would like to merge CharacterGuild and Guild classes into only one but my knowledge on Json is not that good, Blizzard is returning on the same property (depending on how do you call it) two different types (an object and a string for guild or object and int for members)